### PR TITLE
feat: return all signers

### DIFF
--- a/src/CheckNSignatures.sol
+++ b/src/CheckNSignatures.sol
@@ -36,59 +36,19 @@ library CheckSignatures {
         view
         returns (address[] memory recoveredSigners)
     {
-        uint256 requiredSignatureLength = requiredSignatures * 65;
         uint256 signaturesLength = signatures.length;
-        recoveredSigners = new address[](requiredSignatures);
-        if (signaturesLength < requiredSignatureLength) revert InvalidSignature();
-
-        for (uint256 i; i < requiredSignatures; i++) {
+        uint256 totalSignatures = signaturesLength / 65;
+        recoveredSigners = new address[](totalSignatures);
+        if (totalSignatures < requiredSignatures) revert InvalidSignature();
+        uint256 validSigCount;
+        for (uint256 i; i < totalSignatures; i++) {
             // split v,r,s from signatures
             address _signer;
             (uint8 v, bytes32 r, bytes32 s) = signatureSplit({ signatures: signatures, pos: i });
 
             if (v == 0) {
                 // If v is 0 then it is a contract signature
-                // When handling contract signatures the address of the signer contract is encoded
-                // into r
-                _signer = address(uint160(uint256(r)));
-
-                // Check that signature data pointer (s) is not pointing inside the static part of
-                // the signatures bytes
-                // Here we check that the pointer is not pointing inside the part that is being
-                // processed
-                if (uint256(s) < 65 * requiredSignatures) {
-                    revert WrongContractSignatureFormat(uint256(s), 0, 0);
-                }
-
-                if (uint256(s) + 32 > signaturesLength) {
-                    revert WrongContractSignatureFormat(uint256(s), 0, signaturesLength);
-                }
-
-                // Check if the contract signature is in bounds: start of data is s + 32 and end is
-                // start + signature length
-                uint256 contractSignatureLen;
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    contractSignatureLen := mload(add(add(signatures, s), 0x20))
-                }
-                if (uint256(s) + 32 + contractSignatureLen > signaturesLength) {
-                    revert WrongContractSignatureFormat(
-                        uint256(s), contractSignatureLen, signaturesLength
-                    );
-                }
-
-                // Check signature
-                bytes memory contractSignature;
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    // The signature data for contract signatures is appended to the concatenated
-                    // signatures and the offset is stored in s
-                    contractSignature := add(add(signatures, s), 0x20)
-                }
-                if (
-                    ISignatureValidator(_signer).isValidSignature(dataHash, contractSignature)
-                        != EIP1271_MAGIC_VALUE
-                ) revert WrongContractSignature(contractSignature);
+                _signer = isValidContractSignature(dataHash, signatures, r, s, signaturesLength);
             } else if (v > 30) {
                 // If v > 30 then default va (27,28) has been adjusted for eth_sign flow
                 // To support eth_sign and similar we adjust v and hash the messageHash with the
@@ -102,8 +62,61 @@ library CheckSignatures {
             } else {
                 _signer = ECDSA.tryRecover({ hash: dataHash, v: v, r: r, s: s });
             }
-            recoveredSigners[i] = _signer;
+            if (_signer != address(0)) {
+                recoveredSigners[validSigCount++] = _signer;
+            }
         }
+        if (validSigCount < requiredSignatures) revert InvalidSignature();
+    }
+
+    /**
+     * @notice Validates a contract signature following the ERC-1271 standard
+     * @param dataHash Hash of the data that has been signed
+     * @param signatures The concatenated signatures
+     * @param r Signature r value
+     * @param s Signature s value
+     * @param signaturesLength The length of the signatures
+     */
+    function isValidContractSignature(
+        bytes32 dataHash,
+        bytes memory signatures,
+        bytes32 r,
+        bytes32 s,
+        uint256 signaturesLength
+    )
+        internal
+        view
+        returns (address _signer)
+    {
+        // When handling contract signatures the address of the signer contract is encoded
+        // into r
+        _signer = address(uint160(uint256(r)));
+
+        // Check if the contract signature is in bounds: start of data is s + 32 and end is
+        // start + signature length
+        uint256 contractSignatureLen;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            contractSignatureLen := mload(add(add(signatures, s), 0x20))
+        }
+
+        // Check if the contract signature is in bounds
+        if (contractSignatureLen + uint256(s) + 32 > signaturesLength) {
+            return address(0);
+        }
+
+        // Check signature
+        bytes memory contractSignature;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // The signature data for contract signatures is appended to the concatenated
+            // signatures and the offset is stored in s
+            contractSignature := add(add(signatures, s), 0x20)
+        }
+        if (
+            ISignatureValidator(_signer).isValidSignature(dataHash, contractSignature)
+                != EIP1271_MAGIC_VALUE
+        ) return address(0);
     }
 
     /**

--- a/src/CheckNSignatures.sol
+++ b/src/CheckNSignatures.sol
@@ -63,8 +63,9 @@ library CheckSignatures {
                 _signer = ECDSA.tryRecover({ hash: dataHash, v: v, r: r, s: s });
             }
             if (_signer != address(0)) {
-                recoveredSigners[validSigCount++] = _signer;
+                validSigCount++;
             }
+            recoveredSigners[i] = _signer;
         }
         if (validSigCount < requiredSignatures) revert InvalidSignature();
     }

--- a/test/CheckNSignatures.t.sol
+++ b/test/CheckNSignatures.t.sol
@@ -7,9 +7,9 @@ import "../src/CheckNSignatures.sol";
 
 import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 import { CheckNSignaturesFoundryHelper } from "../src/CheckNSignaturesFoundryHelper.sol";
+
 /// @title CheckNSignaturesTest
 /// @author zeroknots
-
 contract ERC1271 is ISignatureValidator {
     function isValidSignature(
         bytes32 _dataHash,
@@ -21,7 +21,10 @@ contract ERC1271 is ISignatureValidator {
         override
         returns (bytes4)
     {
-        return EIP1271_MAGIC_VALUE;
+        if (keccak256(_signature) == keccak256(abi.encodePacked("SIGNATURE"))) {
+            return EIP1271_MAGIC_VALUE;
+        }
+        return 0;
     }
 }
 
@@ -106,22 +109,104 @@ contract CheckNSignaturesTest is Test, CheckNSignaturesFoundryHelper {
 
     function test_ERC1271(bytes memory data) public {
         ERC1271 erc1271Signer = new ERC1271();
-
         bytes32 dataHash = keccak256(data);
 
         bytes memory contractSignature = abi.encodePacked("SIGNATURE");
 
-        uint256 length = contractSignature.length;
+        // Store signature at position after base signature length
+        uint256 signatureOffset = 65;
 
-        uint8 v = 0;
-        console2.log("signer contract", address(erc1271Signer));
-        bytes32 encodedAddr = bytes32(uint256(uint160(address(erc1271Signer))) << 96);
-        bytes32 r = encodedAddr;
-        bytes32 s = bytes32(uint256(30));
-        bytes memory signatures = abi.encodePacked(v, s, r);
-        signatures = abi.encodePacked(signatures, contractSignature);
+        // Format: <owner address 20> <offset to contract signature 32> <signature type 1> <contract
+        // signature>
+        bytes32 r = bytes32(uint256(uint160(address(erc1271Signer)))); // owner
+        bytes32 s = bytes32(signatureOffset); // offset
+        uint8 v = 0; // contract signature type
+
+        bytes memory signatures =
+            abi.encodePacked(r, s, v, bytes32(contractSignature.length), contractSignature);
 
         address[] memory recovered = CheckSignatures.recoverNSignatures(dataHash, signatures, 1);
         assertEq(address(erc1271Signer), recovered[0]);
+    }
+
+    function testSkippedValidSignature() public {
+        (address signer1, uint256 pk1) = makeAddrAndKey("signer1");
+        (address signer2, uint256 pk2) = makeAddrAndKey("signer2");
+        (address signer3, uint256 pk3) = makeAddrAndKey("signer3");
+
+        bytes memory data = abi.encodePacked("DATA TO SIGN");
+        bytes32 dataHash = keccak256(data);
+
+        // Create signatures in order [valid, invalid, valid]
+        // First valid signature
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(pk1, dataHash);
+        bytes memory signatures = abi.encodePacked(r1, s1, v1);
+
+        // Invalid signature (using wrong hash)
+        bytes32 wrongHash = keccak256("WRONG DATA");
+        (v1, r1, s1) = vm.sign(pk2, wrongHash);
+        signatures = abi.encodePacked(signatures, r1, s1, v1);
+
+        // Second valid signature
+        (v1, r1, s1) = vm.sign(pk3, dataHash);
+        signatures = abi.encodePacked(signatures, r1, s1, v1);
+
+        // Try to get 2 valid signatures
+        address[] memory recovered = CheckSignatures.recoverNSignatures(dataHash, signatures, 2);
+
+        // Should get both valid signatures (first and third)
+        assertEq(recovered.length, 3);
+        assert(recovered[0] == signer1);
+        assert(
+            recovered[1] != signer2 && recovered[1] != signer3 && recovered[1] != address(0)
+                && recovered[1] != signer1
+        );
+        assert(recovered[2] == signer3);
+    }
+
+    function testMixedSignatureTypes() public {
+        (address signer1, uint256 pk1) = makeAddrAndKey("signer1");
+        (address signer2, uint256 pk2) = makeAddrAndKey("signer2");
+        ERC1271 erc1271Signer = new ERC1271();
+
+        bytes memory data = abi.encodePacked("DATA TO SIGN");
+        bytes32 dataHash = keccak256(data);
+
+        // First valid ECDSA signature
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(pk1, dataHash);
+        bytes memory signatures = abi.encodePacked(r1, s1, v1);
+
+        // Invalid ECDSA signature
+        (v1, r1, s1) = vm.sign(pk2, bytes32(uint256(dataHash) + 1));
+        signatures = abi.encodePacked(signatures, r1, s1, v1);
+
+        // Valid ERC1271 contract signature
+        bytes memory contractSignature = abi.encodePacked("SIGNATURE");
+        uint256 signatureOffset = signatures.length + 65; // offset after current signatures plus
+            // one more signature slot
+
+        r1 = bytes32(uint256(uint160(address(erc1271Signer))));
+        s1 = bytes32(signatureOffset);
+        v1 = 0;
+
+        signatures = abi.encodePacked(
+            signatures, r1, s1, v1, bytes32(contractSignature.length), contractSignature
+        );
+
+        assembly {
+            mstore(add(add(signatures, signatureOffset), 0x20), mload(contractSignature))
+        }
+
+        // Try to get 2 valid signatures
+        address[] memory recovered = CheckSignatures.recoverNSignatures(dataHash, signatures, 2);
+
+        // Should get both valid signatures (first ECDSA and last ERC1271)
+        assertEq(recovered.length, 3);
+        assertEq(recovered[0], signer1);
+        assert(
+            recovered[1] != signer1 && recovered[1] != address(0)
+                && recovered[1] != address(erc1271Signer) && recovered[1] != signer2
+        );
+        assertEq(recovered[2], address(erc1271Signer));
     }
 }


### PR DESCRIPTION
This is a fix for #3, removes erc1271 early revert and recovers all signers. Theres still some open questions though:

1. do we still need the requiredSignatures param?
2. if yes, should we really always return all signatures? considering the name of the function is to recover N signatures